### PR TITLE
update draggabilly to accept options as an object

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,9 @@ Vue.use(VueDraggabillyPlugin)
 
     <div v-draggabilly v-packery-item class='packery-item'></div>
     <div v-draggabilly v-packery-item class='packery-item'></div>
-    <div v-draggabilly v-packery-item class='packery-item'></div>
+    <div v-draggabilly="{ axis: 'x', containment: true }" v-packery-item class='packery-item'></div>
 
 </div>
 ```
+
+Pass an object with [Draggabilly options](https://draggabilly.desandro.com/) as an argument to the v-draggabilly directive to change the settings.

--- a/src/index.js
+++ b/src/index.js
@@ -11,9 +11,9 @@ export default draggabillyPlugin
 draggabillyPlugin.install = function (Vue, options)
 {
     Vue.directive('draggabilly', {
-        inserted (el)
+        inserted (el, binding)
         {
-            el.draggie = new Draggabilly(el)
+            el.draggie = new Draggabilly(el, binding.value)
             packeryEvents.$emit('draggie', {draggie: draggie, node: el.parentNode})
         },
         unbind (el)


### PR DESCRIPTION
allows to use directive like this:

`v-draggabilly="{ containment: true }"`

Options are found in docs at https://draggabilly.desandro.com/